### PR TITLE
Add optional dep for pyhecdss

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
 
 dynamic = ["version"]
 
+[project.optional-dependencies]
+dss = [
+    "pyhecdss",
+]
+
 [project.urls]
 Homepage = "https://github.com/cadwrdeltamodeling/deltacd"
 Source = "https://github.com/cadwrdeltamodeling/deltacd"


### PR DESCRIPTION
This commit adds an optional dependency `dss` to include `pyhecss`. We do not have `pyhecdss` in PyPI, so this is for the future. Once `pyhecdss` is available in PyPI, it can be installed by running pip as `pip install deltacd[dss]`.

DCD-161