### PR TITLE
Fix a drained leach water bug

### DIFF
--- a/deltacd/dcd.py
+++ b/deltacd/dcd.py
@@ -208,7 +208,7 @@ def use_runoff_for_leach(
         if lwd_adj < 0.0:
             lwd_adj = 0.0
     else:
-        lwd_adj = 0.0
+        lwd_adj = lwd
     return leach_saved, lwa_adj, lwd_adj
 
 


### PR DESCRIPTION
The drained leach water `lwd` calculation was set zero even when it needs to be the full drained leach water. This commit fixes it.